### PR TITLE
Fix Unix time and CloudFeedStatus return

### DIFF
--- a/cmd/cloudfeed.go
+++ b/cmd/cloudfeed.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/energietransitie/needforheat-server-api/handlers"
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/spf13/cobra"
 )
 
@@ -51,11 +52,11 @@ func handleCloudFeedDownload(cmd *cobra.Command, args []string) error {
 		endPeriodFlag = time.Now().Format("2006-01-02")
 	}
 
+	// Parse startPeriodFlag and endPeriodFlag as time strings
 	startPeriod, err := time.Parse("2006-01-02", startPeriodFlag)
 	if err != nil {
 		return err
 	}
-
 	endPeriod, err := time.Parse("2006-01-02", endPeriodFlag)
 	if err != nil {
 		return err
@@ -64,8 +65,8 @@ func handleCloudFeedDownload(cmd *cobra.Command, args []string) error {
 	downloadArgs := handlers.DownloadArgs{
 		AccountID:   accountIDFlag,
 		CloudFeedID: cloudFeedIDFlag,
-		StartPeriod: startPeriod,
-		EndPeriod:   endPeriod,
+		StartPeriod: needforheat.Time(startPeriod),
+		EndPeriod:   needforheat.Time(endPeriod),
 	}
 
 	client, err := getRPCClient()

--- a/handlers/cloudfeed.go
+++ b/handlers/cloudfeed.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/energietransitie/needforheat-server-api/internal/helpers"
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/authorization"
 	"github.com/energietransitie/needforheat-server-api/needforheat/cloudfeed"
 	"github.com/energietransitie/needforheat-server-api/services"
@@ -57,8 +57,8 @@ func (h *CloudFeedHandler) Create(w http.ResponseWriter, r *http.Request) error 
 type DownloadArgs struct {
 	AccountID   uint
 	CloudFeedID uint
-	StartPeriod time.Time
-	EndPeriod   time.Time
+	StartPeriod needforheat.Time
+	EndPeriod   needforheat.Time
 }
 
 // Handle RPC endpoint for downloading data from a cloud feed.

--- a/handlers/device.go
+++ b/handlers/device.go
@@ -247,6 +247,7 @@ func (h *DeviceHandler) GetDevicesByAccount(w http.ResponseWriter, r *http.Reque
 	}
 
 	devices, serviceErr := h.service.GetAllByAccount(auth.ID)
+
 	if serviceErr != nil {
 		return NewHandlerError(serviceErr, "error in getting devices", http.StatusInternalServerError).WithMessage("error in getting devices").WithLevel(logrus.ErrorLevel)
 	}

--- a/needforheat/account/account.go
+++ b/needforheat/account/account.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/campaign"
 	"github.com/energietransitie/needforheat-server-api/needforheat/cloudfeed"
 	"github.com/energietransitie/needforheat-server-api/needforheat/device"
@@ -17,7 +18,7 @@ var (
 type Account struct {
 	ID                 uint                  `json:"id"`
 	Campaign           campaign.Campaign     `json:"campaign"`
-	ActivatedAt        *time.Time            `json:"activated_at"`
+	ActivatedAt        *needforheat.Time     `json:"activated_at"`
 	InvitationToken    string                `json:"invitation_token,omitempty"`
 	InvitationURL      string                `json:"invitation_url,omitempty"`
 	AuthorizationToken string                `json:"authorization_token,omitempty"`
@@ -42,8 +43,9 @@ func (a *Account) Activate() error {
 		return ErrAccountAlreadyActivated
 	}
 
-	now := time.Now().UTC()
-	a.ActivatedAt = &now
+	now := time.Now().Unix()
+	activatedAt := needforheat.Time(time.Unix(now, 0))
+	a.ActivatedAt = &activatedAt
 
 	return nil
 }

--- a/needforheat/campaign/campaign.go
+++ b/needforheat/campaign/campaign.go
@@ -1,8 +1,7 @@
 package campaign
 
 import (
-	"time"
-
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/app"
 	"github.com/energietransitie/needforheat-server-api/needforheat/datasourcelist"
 )
@@ -13,13 +12,13 @@ type Campaign struct {
 	Name           string                        `json:"name"`
 	App            app.App                       `json:"app"`
 	InfoURL        string                        `json:"info_url"`
-	StartTime      *time.Time                    `json:"start_time,omitempty"`
-	EndTime        *time.Time                    `json:"end_time,omitempty"`
+	StartTime      *needforheat.Time             `json:"start_time,omitempty"`
+	EndTime        *needforheat.Time             `json:"end_time,omitempty"`
 	DataSourceList datasourcelist.DataSourceList `json:"data_source_list"`
 }
 
 // Create a new Campaign.
-func MakeCampaign(name string, app app.App, infoURL string, startTime, endTime *time.Time, dataSourceList datasourcelist.DataSourceList) Campaign {
+func MakeCampaign(name string, app app.App, infoURL string, startTime, endTime *needforheat.Time, dataSourceList datasourcelist.DataSourceList) Campaign {
 	return Campaign{
 		Name:           name,
 		App:            app,

--- a/needforheat/cloudfeed/cloudfeed.go
+++ b/needforheat/cloudfeed/cloudfeed.go
@@ -1,21 +1,26 @@
 package cloudfeed
 
-import "time"
+import (
+	"time"
+
+	"github.com/energietransitie/needforheat-server-api/needforheat"
+)
 
 // A CloudFeed stores auth information about CloudFeeds authorized by an account.
 type CloudFeed struct {
-	AccountID       uint       `json:"account_id"`
-	CloudFeedTypeID uint       `json:"cloud_feed_id"`
-	AccessToken     string     `json:"-"`
-	RefreshToken    string     `json:"-"`
-	Expiry          time.Time  `json:"-"`
-	AuthGrantToken  string     `json:"auth_grant_token"`
-	ActivatedAt     *time.Time `json:"activated_at"`
+	AccountID       uint              `json:"account_id"`
+	CloudFeedTypeID uint              `json:"cloud_feed_id"`
+	AccessToken     string            `json:"-"`
+	RefreshToken    string            `json:"-"`
+	Expiry          needforheat.Time  `json:"-"`
+	AuthGrantToken  string            `json:"auth_grant_token"`
+	ActivatedAt     *needforheat.Time `json:"activated_at"`
 }
 
 // Create a new CloudFeed.
-func MakeCloudFeed(accountID, cloudFeedTypeID uint, accessToken string, refreshToken string, expiry time.Time, authGrantToken string) CloudFeed {
-	now := time.Now().UTC()
+func MakeCloudFeed(accountID, cloudFeedTypeID uint, accessToken string, refreshToken string, expiry needforheat.Time, authGrantToken string) CloudFeed {
+	now := time.Now().Unix()
+	activatedAt := needforheat.Time(time.Unix(now, 0))
 	return CloudFeed{
 		AccountID:       accountID,
 		CloudFeedTypeID: cloudFeedTypeID,
@@ -23,6 +28,6 @@ func MakeCloudFeed(accountID, cloudFeedTypeID uint, accessToken string, refreshT
 		RefreshToken:    refreshToken,
 		Expiry:          expiry,
 		AuthGrantToken:  authGrantToken,
-		ActivatedAt:     &now,
+		ActivatedAt:     &activatedAt,
 	}
 }

--- a/needforheat/cloudfeed/repository.go
+++ b/needforheat/cloudfeed/repository.go
@@ -1,8 +1,7 @@
 package cloudfeed
 
 import (
-	"time"
-
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/device"
 )
 
@@ -10,7 +9,7 @@ import (
 type CloudFeedRepository interface {
 	Find(CloudFeed CloudFeed) (CloudFeed, error)
 	FindOAuthInfo(accountID uint, cloudFeedID uint) (tokenURL string, refreshToken string, clientID string, clientSecret string, err error)
-	FindFirstTokenToExpire() (accountID uint, cloudFeedID uint, expiry time.Time, err error)
+	FindFirstTokenToExpire() (accountID uint, cloudFeedID uint, expiry needforheat.Time, err error)
 	FindDevice(CloudFeed CloudFeed) (*device.Device, error)
 	GetAll() ([]CloudFeed, error)
 	Create(CloudFeed) (CloudFeed, error)

--- a/needforheat/cloudfeedstatus/cloudfeedstatus.go
+++ b/needforheat/cloudfeedstatus/cloudfeedstatus.go
@@ -7,8 +7,8 @@ import (
 
 // A CloudFeedStatus contains all available cloud feeds for an account and if they are connected or not.
 type CloudFeedStatus struct {
-	CloudFeed cloudfeed.CloudFeed `json:"cloud_feed"`
-	Connected bool                `json:"connected"`
+	CloudFeedType cloudfeedtype.CloudFeedType `json:"cloud_feed_type"`
+	Connected     bool                        `json:"connected"`
 }
 
 // Create a new CloudFeedStatus.
@@ -19,7 +19,7 @@ func MakeCloudFeedStatus(cloudFeedType cloudfeedtype.CloudFeedType, cloudFeed cl
 	connected := cloudFeed.AuthGrantToken != ""
 
 	return CloudFeedStatus{
-		CloudFeed: cloudFeed,
-		Connected: connected,
+		CloudFeedType: cloudFeedType,
+		Connected:     connected,
 	}
 }

--- a/needforheat/device/device.go
+++ b/needforheat/device/device.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/devicetype"
 	"github.com/energietransitie/needforheat-server-api/needforheat/upload"
 	"github.com/sirupsen/logrus"
@@ -22,10 +23,10 @@ type Device struct {
 	AccountID            uint                  `json:"account_id"`
 	ActivationSecret     string                `json:"activation_secret,omitempty"` // This can be removed if a device uses JWT's too.
 	ActivationSecretHash string                `json:"-"`                           // This can be removed if a device uses JWT's too.
-	ActivatedAt          *time.Time            `json:"activated_at"`
+	ActivatedAt          *needforheat.Time     `json:"activated_at"`
 	AuthorizationToken   string                `json:"authorization_token,omitempty"`
 	Uploads              []upload.Upload       `json:"uploads,omitempty"`
-	LatestUpload         *time.Time            `json:"latest_upload"`
+	LatestUpload         *needforheat.Time     `json:"latest_upload,omitempty"`
 }
 
 // Create a new Device.
@@ -49,8 +50,9 @@ func (d *Device) Activate(activationSecret string) error {
 		return ErrDeviceActivationSecretIncorrect
 	}
 
-	now := time.Now().UTC()
-	d.ActivatedAt = &now
+	now := time.Now().Unix()
+	activatedAt := needforheat.Time(time.Unix(now, 0))
+	d.ActivatedAt = &activatedAt
 
 	return nil
 }

--- a/needforheat/device/repository.go
+++ b/needforheat/device/repository.go
@@ -1,8 +1,7 @@
 package device
 
 import (
-	"time"
-
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/measurement"
 	"github.com/energietransitie/needforheat-server-api/needforheat/property"
 )
@@ -10,7 +9,7 @@ import (
 // A DeviceRepository can load, store and delete devices.
 type DeviceRepository interface {
 	Find(device Device) (Device, error)
-	FindCloudFeedAuthCreationTimeFromDeviceID(deviceID uint) (*time.Time, error)
+	FindCloudFeedAuthCreationTimeFromDeviceID(deviceID uint) (*needforheat.Time, error)
 	GetProperties(device Device) ([]property.Property, error)
 	GetMeasurements(device Device, filters map[string]string) ([]measurement.Measurement, error)
 	GetAll() ([]Device, error)

--- a/needforheat/time.go
+++ b/needforheat/time.go
@@ -1,31 +1,46 @@
 package needforheat
 
 import (
+	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
-// A Time is a wrapper for time.Time that can be unmarshalled into unix seconds in JSON.
+// Time is a wrapper for time.Time that can be unmarshalled into unix seconds in JSON.
 type Time time.Time
 
+// MarshalJSON marshals the Time to Unix seconds.
 func (t Time) MarshalJSON() ([]byte, error) {
-	return json.Marshal(time.Time(t))
+	unixSeconds := time.Time(t).Unix()
+	return json.Marshal(unixSeconds)
 }
 
-// Unmarshal JSON to Time. Unix seconds.
+// UnmarshalJSON unmarshals Unix seconds to Time.
 func (t *Time) UnmarshalJSON(b []byte) error {
-	unixTime, err := UnmarshalUnix(b)
-
-	*t = Time(unixTime)
-	return err
-}
-
-func UnmarshalUnix(b []byte) (time.Time, error) {
 	var unixSeconds int64
 	err := json.Unmarshal(b, &unixSeconds)
 	if err != nil {
-		return time.Time{}, err
+		return err
 	}
 
-	return time.Unix(unixSeconds, 0), nil
+	*t = Time(time.Unix(unixSeconds, 0))
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (t Time) Value() (driver.Value, error) {
+	return time.Time(t), nil
+}
+
+// Scan implements the sql.Scanner interface.
+func (t *Time) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	if v, ok := value.(time.Time); ok {
+		*t = Time(v)
+		return nil
+	}
+	return fmt.Errorf("failed to scan Time field")
 }

--- a/repositories/account.go
+++ b/repositories/account.go
@@ -2,8 +2,7 @@
 package repositories
 
 import (
-	"time"
-
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/account"
 	"gorm.io/gorm"
 )
@@ -23,7 +22,7 @@ type AccountModel struct {
 	gorm.Model
 	CampaignModelID uint `gorm:"column:campaign_id"`
 	Campaign        CampaignModel
-	ActivatedAt     *time.Time
+	ActivatedAt     *needforheat.Time
 	CloudFeeds      []CloudFeedModel `gorm:"foreignKey:AccountID"`
 	Devices         []DeviceModel
 }

--- a/repositories/campaign.go
+++ b/repositories/campaign.go
@@ -1,8 +1,7 @@
 package repositories
 
 import (
-	"time"
-
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/campaign"
 	"gorm.io/gorm"
 )
@@ -24,8 +23,8 @@ type CampaignModel struct {
 	AppModelID       uint   `gorm:"column:app_id"`
 	App              AppModel
 	InfoURL          string `gorm:"unique;not null"`
-	StartTime        *time.Time
-	EndTime          *time.Time
+	StartTime        *needforheat.Time
+	EndTime          *needforheat.Time
 	DataSourceListID uint
 }
 

--- a/repositories/cloudfeed.go
+++ b/repositories/cloudfeed.go
@@ -1,10 +1,9 @@
 package repositories
 
 import (
-	"time"
-
 	"github.com/energietransitie/needforheat-server-api/internal/encryption"
 	"github.com/energietransitie/needforheat-server-api/internal/helpers"
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/cloudfeed"
 	"github.com/energietransitie/needforheat-server-api/needforheat/device"
 	"gorm.io/gorm"
@@ -24,15 +23,15 @@ func NewCloudFeedRepository(db *gorm.DB) *CloudFeedRepository {
 type CloudFeedModel struct {
 	AccountID       uint `gorm:"primaryKey;autoIncrement:false"`
 	CloudFeedTypeID uint `gorm:"primaryKey;autoIncrement:false"`
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	CreatedAt       needforheat.Time
+	UpdatedAt       needforheat.Time
 	DeletedAt       gorm.DeletedAt `gorm:"index"`
 	// TODO: WARNING encrypted string encryption not yet implemented.
 	AccessToken    encryption.EncryptedString
 	RefreshToken   encryption.EncryptedString
-	Expiry         time.Time
+	Expiry         needforheat.Time
 	AuthGrantToken encryption.EncryptedString
-	ActivatedAt    *time.Time
+	ActivatedAt    *needforheat.Time
 }
 
 // Set the name of the table in the database.
@@ -83,7 +82,7 @@ func (r *CloudFeedRepository) FindOAuthInfo(accountID uint, cloudFeedID uint) (s
 	return result.TokenURL, result.RefreshToken, result.ClientID, result.ClientSecret, err
 }
 
-func (r *CloudFeedRepository) FindFirstTokenToExpire() (uint, uint, time.Time, error) {
+func (r *CloudFeedRepository) FindFirstTokenToExpire() (uint, uint, needforheat.Time, error) {
 	var cloudFeedModel CloudFeedModel
 	err := r.db.Order("expiry ASC").Where("expiry <> ''").First(&cloudFeedModel).Error
 	return cloudFeedModel.AccountID, cloudFeedModel.CloudFeedTypeID, cloudFeedModel.Expiry, err

--- a/repositories/device.go
+++ b/repositories/device.go
@@ -1,8 +1,7 @@
 package repositories
 
 import (
-	"time"
-
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/device"
 	"github.com/energietransitie/needforheat-server-api/needforheat/measurement"
 	"github.com/energietransitie/needforheat-server-api/needforheat/property"
@@ -29,7 +28,7 @@ type DeviceModel struct {
 	DeviceType           DeviceTypeModel
 	AccountModelID       uint `gorm:"column:account_id"`
 	ActivationSecretHash string
-	ActivatedAt          *time.Time
+	ActivatedAt          *needforheat.Time
 	Uploads              []UploadModel `gorm:"foreignKey:InstanceID"`
 }
 
@@ -83,9 +82,9 @@ func (r *DeviceRepository) Find(device device.Device) (device.Device, error) {
 	return deviceModel.fromModel(), err
 }
 
-func (r *DeviceRepository) FindCloudFeedAuthCreationTimeFromDeviceID(deviceID uint) (*time.Time, error) {
+func (r *DeviceRepository) FindCloudFeedAuthCreationTimeFromDeviceID(deviceID uint) (*needforheat.Time, error) {
 	result := struct {
-		CreatedAt time.Time
+		CreatedAt needforheat.Time
 	}{}
 
 	err := r.db.

--- a/repositories/upload.go
+++ b/repositories/upload.go
@@ -1,8 +1,6 @@
 package repositories
 
 import (
-	"time"
-
 	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/measurement"
 	"github.com/energietransitie/needforheat-server-api/needforheat/upload"
@@ -24,8 +22,8 @@ func NewUploadRepository(db *gorm.DB) *UploadRepository {
 type UploadModel struct {
 	gorm.Model
 	InstanceID   uint `gorm:"column:instance_id"`
-	ServerTime   time.Time
-	DeviceTime   time.Time
+	ServerTime   needforheat.Time
+	DeviceTime   needforheat.Time
 	Size         int
 	Measurements []MeasurementModel
 }
@@ -46,8 +44,8 @@ func MakeUploadModel(upload upload.Upload) UploadModel {
 	return UploadModel{
 		Model:        gorm.Model{ID: upload.ID},
 		InstanceID:   upload.InstanceID,
-		ServerTime:   time.Time(upload.ServerTime),
-		DeviceTime:   time.Time(upload.DeviceTime),
+		ServerTime:   upload.ServerTime,
+		DeviceTime:   upload.DeviceTime,
 		Size:         upload.Size,
 		Measurements: measurementModels,
 	}

--- a/services/campaign.go
+++ b/services/campaign.go
@@ -1,8 +1,7 @@
 package services
 
 import (
-	"time"
-
+	"github.com/energietransitie/needforheat-server-api/needforheat"
 	"github.com/energietransitie/needforheat-server-api/needforheat/app"
 	"github.com/energietransitie/needforheat-server-api/needforheat/campaign"
 	"github.com/energietransitie/needforheat-server-api/needforheat/datasourcelist"
@@ -36,7 +35,7 @@ func (s *CampaignService) Create(
 	app app.App,
 	infoURL string,
 	startTime,
-	endTime *time.Time,
+	endTime *needforheat.Time,
 	dataSourceList datasourcelist.DataSourceList,
 ) (campaign.Campaign, error) {
 	app, err := s.appService.Find(app)

--- a/services/cloudfeed.go
+++ b/services/cloudfeed.go
@@ -28,7 +28,7 @@ const (
 var (
 	ErrDuplicateCloudFeed = errors.New("duplicate cloud feed auth")
 
-	NoLatestUploadTime = time.Time{}
+	NoLatestUploadTime = needforheat.Time{}
 )
 
 type CloudFeedService struct {
@@ -74,7 +74,7 @@ func (s *CloudFeedService) Create(ctx context.Context, accountID, cloudFeedTypeI
 		return cloudfeed.CloudFeed{}, err
 	}
 
-	cloudFeed := cloudfeed.MakeCloudFeed(accountID, cloudFeedTypeID, accessToken, refreshToken, expiry, authGrantToken)
+	cloudFeed := cloudfeed.MakeCloudFeed(accountID, cloudFeedTypeID, accessToken, refreshToken, needforheat.Time(expiry), authGrantToken)
 
 	cloudFeed, err = s.cloudFeedRepo.Create(cloudFeed)
 	if err != nil {
@@ -166,7 +166,9 @@ func (s *CloudFeedService) RefreshTokens(ctx context.Context, accountID uint, cl
 
 	cloudFeed.AccessToken = response.AccessToken
 	cloudFeed.RefreshToken = response.RefreshToken
-	cloudFeed.Expiry = time.Now().Add(time.Second * time.Duration(response.ExpiresIn))
+
+	expiryUnix := time.Now().Add(time.Second * time.Duration(response.ExpiresIn)).Unix()
+	cloudFeed.Expiry = needforheat.Time(time.Unix(expiryUnix, 0))
 
 	return s.cloudFeedRepo.Update(cloudFeed)
 }
@@ -188,7 +190,7 @@ refreshLoop:
 			continue
 		}
 
-		timerDuration := time.Until(expiry) - preRenewalDuration
+		timerDuration := time.Until(time.Time(expiry)) - preRenewalDuration
 		if timerDuration < 0 {
 			// Wait 10 seconds to prevent a possible flood of refresh requests.
 			time.Sleep(time.Second * 10)
@@ -289,7 +291,10 @@ func (s *CloudFeedService) download(ctx context.Context) error {
 			*latestUpload = NoLatestUploadTime
 		}
 
-		err = s.Download(ctx, cfa, *latestUpload, time.Now())
+		now := time.Now().Unix()
+		unixNow := needforheat.Time(time.Unix(now, 0))
+
+		err = s.Download(ctx, cfa, *latestUpload, unixNow)
 		if err != nil {
 			logrus.Warningln(err)
 		}
@@ -300,7 +305,7 @@ func (s *CloudFeedService) download(ctx context.Context) error {
 
 // Download data from a cloud feed using the cloud feed auth and store it in the database.
 // startPeriod and endPeriod are the time periods for which data should be downloaded.
-func (s *CloudFeedService) Download(ctx context.Context, cfa cloudfeed.CloudFeed, startPeriod time.Time, endPeriod time.Time) error {
+func (s *CloudFeedService) Download(ctx context.Context, cfa cloudfeed.CloudFeed, startPeriod needforheat.Time, endPeriod needforheat.Time) error {
 	logrus.Infoln("downloading data from cloud feed auth with accountID", cfa.AccountID, "cloudFeedTypeID", cfa.CloudFeedTypeID)
 
 	device, err := s.cloudFeedRepo.FindDevice(cfa)
@@ -308,7 +313,7 @@ func (s *CloudFeedService) Download(ctx context.Context, cfa cloudfeed.CloudFeed
 		return fmt.Errorf("error finding device for cloud feed auth: %w", err)
 	}
 
-	measurements, err := enelogic.Download(ctx, cfa.AccessToken, startPeriod, endPeriod)
+	measurements, err := enelogic.Download(ctx, cfa.AccessToken, time.Time(startPeriod), time.Time(endPeriod))
 	if err != nil {
 		if err == enelogic.ErrNoData {
 			logrus.Infoln("no (new) data found for cloud feed auth with accountID", cfa.AccountID, "cloudFeedTypeID", cfa.CloudFeedTypeID)

--- a/services/device.go
+++ b/services/device.go
@@ -69,6 +69,7 @@ func (s *DeviceService) GetByName(name string) (device.Device, error) {
 	}
 
 	d.LatestUpload, _, err = s.uploadService.GetLatestUploadTimeForDeviceWithID(d.ID)
+
 	if err != nil {
 		return device.Device{}, err
 	}
@@ -146,6 +147,7 @@ func (s *DeviceService) GetAllByAccount(accountId uint) ([]device.Device, error)
 
 	for _, device := range devices {
 		device.LatestUpload, _, err = s.uploadService.GetLatestUploadTimeForDeviceWithID(device.ID)
+
 		if err != nil {
 			return nil, err
 		}

--- a/services/upload.go
+++ b/services/upload.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"errors"
-	"time"
 
 	"github.com/energietransitie/needforheat-server-api/internal/helpers"
 	"github.com/energietransitie/needforheat-server-api/needforheat"
@@ -44,8 +43,9 @@ func (s *UploadService) Create(deviceID uint, deviceTime needforheat.Time, measu
 	return upload, err
 }
 
-func (s *UploadService) GetLatestUploadTimeForDeviceWithID(id uint) (*time.Time, bool, error) {
+func (s *UploadService) GetLatestUploadTimeForDeviceWithID(id uint) (*needforheat.Time, bool, error) {
 	upload, err := s.repository.GetLatestUploadForDeviceWithID(id)
+
 	if err != nil {
 		// If the record is not found, there was no upload. That's not an error.
 		if helpers.IsMySQLRecordNotFoundError(err) {
@@ -55,10 +55,10 @@ func (s *UploadService) GetLatestUploadTimeForDeviceWithID(id uint) (*time.Time,
 		return nil, false, err
 	}
 
-	return (*time.Time)(&upload.ServerTime), true, nil
+	return (*needforheat.Time)(&upload.ServerTime), true, nil
 }
 
-func (s *UploadService) getCloudFeedAuthCreationTimeForDeviceWithID(id uint) (*time.Time, error) {
+func (s *UploadService) getCloudFeedAuthCreationTimeForDeviceWithID(id uint) (*needforheat.Time, error) {
 	creationTime, err := s.deviceRepo.FindCloudFeedAuthCreationTimeFromDeviceID(id)
 	if err != nil && !helpers.IsMySQLRecordNotFoundError(err) {
 		return nil, err


### PR DESCRIPTION
Everything (apart from CloudFeed right now) now uses Unix time based on GMT UTC 0.

Also fixes the API return for CloudFeedStatus as the refactor accidentally returned the CloudFeed and not CloudFeedType