### PR TITLE
HotFix: Change API return type to name for energyqueryvariety

### DIFF
--- a/needforheat/energyquerytype/energyquerytype.go
+++ b/needforheat/energyquerytype/energyquerytype.go
@@ -3,7 +3,7 @@ package energyquerytype
 // A EnergyQueryType contains information about a group of energyqueries with the same functionality.
 type EnergyQueryType struct {
 	ID                 uint   `json:"id"`
-	EnergyQueryVariety string `json:"energy_query_variety"`
+	EnergyQueryVariety string `json:"name"`
 	Formula            string `json:"formula"`
 }
 


### PR DESCRIPTION
App expects `Name` and I do not want to hack it in